### PR TITLE
Add linked clone support for "parallels" provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ For more info about GUI vs. Headless mode please see [vagrant configuration docs
 
 ### <a name="config-linked_clone"></a> linked_clone
 
-Allows to use linked clones to import boxes for VirtualBox and VMware. Default is **nil**.
+Allows to use linked clones to import boxes for VirtualBox, VMware and Parallels Desktop. Default is **nil**.
 
 ```yaml
 ---

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1212,6 +1212,36 @@ describe Kitchen::Driver::Vagrant do
           end
         RUBY
       end
+
+      it "does not set :linked_clone to nil" do
+        config[:linked_clone] = nil
+        cmd
+
+        expect(vagrantfile).to_not match(
+          regexify(%{p.linked_clone = }, :partial))
+      end
+
+      it "sets :linked_clone to false if set" do
+        config[:linked_clone] = false
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :parallels do |p|
+            p.linked_clone = false
+          end
+        RUBY
+      end
+
+      it "sets :linked_clone to true if set" do
+        config[:linked_clone] = true
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :parallels do |p|
+            p.linked_clone = true
+          end
+        RUBY
+      end
     end
 
     context "for rackspace provider" do

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -77,10 +77,15 @@ Vagrant.configure("2") do |c|
      if config[:gui] == true || config[:gui] == false %>
     p.gui = <%= config[:gui] %>
 <%   end
+   end
+
+   case config[:provider]
+   when "virtualbox", /^vmware_/, "parallels"
      if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end
    end %>
+
 <% config[:customize].each do |key, value| %>
   <% case config[:provider]
      when "libvirt" %>


### PR DESCRIPTION
Hi @bborysenko,

I just want to append your PR https://github.com/test-kitchen/kitchen-vagrant/pull/203
`parallels` provider supports `linked_clone` option starting from [v1.6.0](https://github.com/Parallels/vagrant-parallels/releases/tag/v1.6.0)